### PR TITLE
Fix/handling parent path with baseroute

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ import path from "path";
 const routes = new ERH({
 	app: express(),
 	endpointsFolder: path.join(__dirname, "endpoints"),
-	useParentPath: true,
 	baseRoute: "/api/v1/",
 });
 ```
@@ -68,7 +67,6 @@ const path = require("path");
 const routes = new ERH({
 	app: express(),
 	endpointsFolder: path.join(__dirname, "endpoints"),
-	useParentPath: true,
 	baseRoute: "/api/v1/",
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kromi77/express-rh",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.2-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kromi77/express-rh",
-      "version": "0.0.1-alpha.1",
+      "version": "0.0.2-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@express-rate-limit/tsconfig": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kromi77/express-rh",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.2-alpha.1",
   "description": "Self created routes handler for express.js",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,9 @@ class ERH {
 		
 		this._host = host ?? "localhost";
 		this._port = port ?? 3000;
+
+		if (this._useParentPath && this._baseRoute != "/") throw new Error(pc.red("ERH > You can't use parent path with base route"));
+		
 		this._useParentPath = useParentPath ?? false;
 		
 		if (staticBasePath) this._staticBasePath = staticBasePath;


### PR DESCRIPTION
This pull request contains hot fix to patch a error when useParentPath option is set to true and base path is custom